### PR TITLE
fix: reject invalid absolute URLs in URI.fromResult

### DIFF
--- a/ts/src/uri.test.ts
+++ b/ts/src/uri.test.ts
@@ -447,6 +447,20 @@ describe("URI", () => {
     expect(URI.from("/bla").toString()).equal("file:///bla");
   });
 
+  it("hostpart protocol with no host returns Err in fromResult", () => {
+    for (const proto of ["http://", "https://", "ws://", "wss://"]) {
+      const rUri = URI.fromResult(proto);
+      expect(rUri.isErr(), `${proto} should be Err`).toBe(true);
+    }
+  });
+
+  it("non-hostpart protocol parses ok", () => {
+    for (const proto of ["sxy://", "file://", "custom://"]) {
+      const rUri = URI.fromResult(proto);
+      expect(rUri.isOk(), `${proto} should be Ok`).toBe(true);
+    }
+  });
+
   describe("applyBase", () => {
     let base: BuildURI;
     let ref: BuildURI;

--- a/ts/src/uri.ts
+++ b/ts/src/uri.ts
@@ -161,7 +161,13 @@ function ensureURLWithDefaultProto<T>(
   if (typeof url === "string") {
     try {
       return action.fromThrow(url);
-    } catch (_e) {
+    } catch (e) {
+      // Only re-throw for protocols that require a host part (http, https, ws, wss).
+      // Non-hostpart protocols (file://, custom://) still get the defaultProtocol fallback.
+      const protoMatch = url.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+      if (protoMatch && hasHostPartProtocols.has(protoMatch[1])) {
+        throw e;
+      }
       return action.fromThrow(`${defaultProtocol}//${url}`);
     }
   } else {


### PR DESCRIPTION
## Summary
- URLs with an explicit protocol (e.g. `http://`) that fail to parse now re-throw instead of silently falling back to `file://http://`
- Bare strings without a protocol (`"bla"`, `"/bla"`) still get the `file://` fallback as before
- Adds test for `URI.fromResult("http://")` returning `Err`

## Test plan
- [x] `pnpm test` — all 695 tests pass (node, cf-runtime, browser)
- [x] `pnpm lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling: protocol-qualified addresses (e.g., http/https/ws/wss) now preserve original errors instead of falling back to a default protocol, avoiding unintended parsing behavior.

* **Tests**
  * Added tests covering protocol-qualified inputs: one asserting error for host-part protocols with no host, and one confirming parsing for non-hostpart protocols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->